### PR TITLE
draft: add NATS support for streaming subscription

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -39,6 +39,7 @@ require (
 	github.com/lestrrat-go/jwx/v2 v2.0.21
 	github.com/microsoft/durabletask-go v0.5.0
 	github.com/mitchellh/mapstructure v1.5.1-0.20220423185008-bf980b35cac4
+	github.com/nats-io/nats.go v1.37.0
 	github.com/phayes/freeport v0.0.0-20220201140144-74d24b5ae9f5
 	github.com/prometheus/client_golang v1.20.4
 	github.com/prometheus/client_model v0.6.1
@@ -343,7 +344,6 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f // indirect
 	github.com/natefinch/lumberjack v2.0.0+incompatible // indirect
-	github.com/nats-io/nats.go v1.37.0 // indirect
 	github.com/nats-io/nkeys v0.4.7 // indirect
 	github.com/nats-io/nuid v1.0.1 // indirect
 	github.com/ncruces/go-strftime v0.1.9 // indirect

--- a/go.mod
+++ b/go.mod
@@ -343,8 +343,8 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f // indirect
 	github.com/natefinch/lumberjack v2.0.0+incompatible // indirect
-	github.com/nats-io/nats.go v1.28.0 // indirect
-	github.com/nats-io/nkeys v0.4.6 // indirect
+	github.com/nats-io/nats.go v1.37.0 // indirect
+	github.com/nats-io/nkeys v0.4.7 // indirect
 	github.com/nats-io/nuid v1.0.1 // indirect
 	github.com/ncruces/go-strftime v0.1.9 // indirect
 	github.com/open-policy-agent/opa v0.68.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1264,14 +1264,10 @@ github.com/nats-io/nats-server/v2 v2.1.2/go.mod h1:Afk+wRZqkMQs/p45uXdrVLuab3gwv
 github.com/nats-io/nats-server/v2 v2.9.23 h1:6Wj6H6QpP9FMlpCyWUaNu2yeZ/qGj+mdRkZ1wbikExU=
 github.com/nats-io/nats-server/v2 v2.9.23/go.mod h1:wEjrEy9vnqIGE4Pqz4/c75v9Pmaq7My2IgFmnykc4C0=
 github.com/nats-io/nats.go v1.9.1/go.mod h1:ZjDU1L/7fJ09jvUSRVBR2e7+RnLiiIQyqyzEE/Zbp4w=
-github.com/nats-io/nats.go v1.28.0 h1:Th4G6zdsz2d0OqXdfzKLClo6bOfoI/b1kInhRtFIy5c=
-github.com/nats-io/nats.go v1.28.0/go.mod h1:XpbWUlOElGwTYbMR7imivs7jJj9GtK7ypv321Wp6pjc=
 github.com/nats-io/nats.go v1.37.0 h1:07rauXbVnnJvv1gfIyghFEo6lUcYRY0WXc3x7x0vUxE=
 github.com/nats-io/nats.go v1.37.0/go.mod h1:Ubdu4Nh9exXdSz0RVWRFBbRfrbSxOYd26oF0wkWclB8=
 github.com/nats-io/nkeys v0.1.0/go.mod h1:xpnFELMwJABBLVhffcfd1MZx6VsNRFpEugbxziKVo7w=
 github.com/nats-io/nkeys v0.1.3/go.mod h1:xpnFELMwJABBLVhffcfd1MZx6VsNRFpEugbxziKVo7w=
-github.com/nats-io/nkeys v0.4.6 h1:IzVe95ru2CT6ta874rt9saQRkWfe2nFj1NtvYSLqMzY=
-github.com/nats-io/nkeys v0.4.6/go.mod h1:4DxZNzenSVd1cYQoAa8948QY3QDjrHfcfVADymtkpts=
 github.com/nats-io/nkeys v0.4.7 h1:RwNJbbIdYCoClSDNY7QVKZlyb/wfT6ugvFCiKy6vDvI=
 github.com/nats-io/nkeys v0.4.7/go.mod h1:kqXRgRDPlGy7nGaEDMuYzmiJCIAAWDK0IMBtDmGD0nc=
 github.com/nats-io/nuid v1.0.1 h1:5iA8DT8V7q8WK2EScv2padNa/rTESc1KdnPw4TC2paw=

--- a/go.sum
+++ b/go.sum
@@ -1266,10 +1266,14 @@ github.com/nats-io/nats-server/v2 v2.9.23/go.mod h1:wEjrEy9vnqIGE4Pqz4/c75v9Pmaq
 github.com/nats-io/nats.go v1.9.1/go.mod h1:ZjDU1L/7fJ09jvUSRVBR2e7+RnLiiIQyqyzEE/Zbp4w=
 github.com/nats-io/nats.go v1.28.0 h1:Th4G6zdsz2d0OqXdfzKLClo6bOfoI/b1kInhRtFIy5c=
 github.com/nats-io/nats.go v1.28.0/go.mod h1:XpbWUlOElGwTYbMR7imivs7jJj9GtK7ypv321Wp6pjc=
+github.com/nats-io/nats.go v1.37.0 h1:07rauXbVnnJvv1gfIyghFEo6lUcYRY0WXc3x7x0vUxE=
+github.com/nats-io/nats.go v1.37.0/go.mod h1:Ubdu4Nh9exXdSz0RVWRFBbRfrbSxOYd26oF0wkWclB8=
 github.com/nats-io/nkeys v0.1.0/go.mod h1:xpnFELMwJABBLVhffcfd1MZx6VsNRFpEugbxziKVo7w=
 github.com/nats-io/nkeys v0.1.3/go.mod h1:xpnFELMwJABBLVhffcfd1MZx6VsNRFpEugbxziKVo7w=
 github.com/nats-io/nkeys v0.4.6 h1:IzVe95ru2CT6ta874rt9saQRkWfe2nFj1NtvYSLqMzY=
 github.com/nats-io/nkeys v0.4.6/go.mod h1:4DxZNzenSVd1cYQoAa8948QY3QDjrHfcfVADymtkpts=
+github.com/nats-io/nkeys v0.4.7 h1:RwNJbbIdYCoClSDNY7QVKZlyb/wfT6ugvFCiKy6vDvI=
+github.com/nats-io/nkeys v0.4.7/go.mod h1:kqXRgRDPlGy7nGaEDMuYzmiJCIAAWDK0IMBtDmGD0nc=
 github.com/nats-io/nuid v1.0.1 h1:5iA8DT8V7q8WK2EScv2padNa/rTESc1KdnPw4TC2paw=
 github.com/nats-io/nuid v1.0.1/go.mod h1:19wcPz3Ph3q0Jbyiqsd0kePYG7A95tJPxeL+1OSON2c=
 github.com/ncruces/go-strftime v0.1.9 h1:bY0MQC28UADQmHmaF5dgpLmImcShSi2kHU9XLdhx/f4=

--- a/pkg/api/grpc/grpc.go
+++ b/pkg/api/grpc/grpc.go
@@ -72,8 +72,6 @@ const (
 
 type PublishEventCallback func(ctx context.Context, subject string, data []byte) error
 
-var natsPublishCallback PublishEventCallback
-
 // API is the gRPC interface for the Dapr gRPC API. It implements both the internal and external proto definitions.
 type API interface {
 	io.Closer
@@ -144,11 +142,6 @@ func NewAPI(opts APIOpts) API {
 		// for catalyst NATS eventing
 		natsPublishCallback: opts.NatsPublishCallback,
 	}
-}
-
-// RegisterNATSCallback registers a callback for publishing to NATS
-func RegisterNATSCallback(callback PublishEventCallback) {
-	natsPublishCallback = callback
 }
 
 // validateAndGetPubsubAndTopic validates the request parameters and returns the pubsub interface, pubsub name, topic name, rawPayload metadata if set

--- a/pkg/api/grpc/grpc.go
+++ b/pkg/api/grpc/grpc.go
@@ -63,6 +63,7 @@ import (
 	"github.com/dapr/dapr/utils"
 	kiterrors "github.com/dapr/kit/errors"
 	"github.com/dapr/kit/logger"
+	"github.com/nats-io/nats.go"
 )
 
 const (
@@ -99,6 +100,9 @@ type api struct {
 	closed                atomic.Bool
 	closeCh               chan struct{}
 	wg                    sync.WaitGroup
+
+	natsConn *nats.Conn
+	natsJS   nats.JetStreamContext
 }
 
 // APIOpts contains options for NewAPI.
@@ -114,6 +118,9 @@ type APIOpts struct {
 	TracingSpec           config.TracingSpec
 	AccessControlList     *config.AccessControlList
 	Processor             *processor.Processor
+
+	NATSConn *nats.Conn
+	NATSJS   nats.JetStreamContext
 }
 
 // NewAPI returns a new gRPC API.
@@ -132,6 +139,9 @@ func NewAPI(opts APIOpts) API {
 		accessControlList:     opts.AccessControlList,
 		processor:             opts.Processor,
 		closeCh:               make(chan struct{}),
+
+		natsConn: opts.NATSConn,
+		natsJS:   opts.NATSJS,
 	}
 }
 

--- a/pkg/api/grpc/subscribe.go
+++ b/pkg/api/grpc/subscribe.go
@@ -121,9 +121,9 @@ func (a *api) streamSubscribe(stream runtimev1pb.Dapr_SubscribeTopicEventsAlpha1
 	}
 
 	if a.natsPublishCallback != nil {
-		err = a.natsPublishCallback(context.Background(), subject, []byte(msgData))
+		err = a.natsPublishCallback(context.Background(), subject, msgData)
 		if err != nil {
-			fmt.Errorf("NATS publish error: %v", err)
+			fmt.Printf("NATS publish error: %v", err)
 			// Continue with subscription even if publishing fails
 		}
 	}

--- a/pkg/api/grpc/subscribe.go
+++ b/pkg/api/grpc/subscribe.go
@@ -24,7 +24,10 @@ import (
 
 	subapi "github.com/dapr/dapr/pkg/apis/subscriptions/v2alpha1"
 	runtimev1pb "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/kit/logger"
 )
+
+var log = logger.NewLogger("catalyst.nats")
 
 // SubscribeTopicEvents is called by the Dapr runtime to ad hoc stream
 // subscribe to topics. If gRPC API server closes, returns func early with nil
@@ -123,7 +126,7 @@ func (a *api) streamSubscribe(stream runtimev1pb.Dapr_SubscribeTopicEventsAlpha1
 	if a.natsPublishCallback != nil {
 		err = a.natsPublishCallback(context.Background(), subject, msgData)
 		if err != nil {
-			fmt.Printf("NATS publish error: %v", err)
+			log.Errorf("NATS publish error: %v", err)
 			// Continue with subscription even if publishing fails
 		}
 	}

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -27,6 +27,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/nats-io/nats.go"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace"
 	otlptracegrpc "go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
 	otlptracehttp "go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
@@ -86,7 +87,6 @@ import (
 	"github.com/dapr/dapr/utils"
 	"github.com/dapr/kit/concurrency"
 	"github.com/dapr/kit/logger"
-	"github.com/nats-io/nats.go"
 )
 
 var log = logger.NewLogger("dapr.runtime")
@@ -1462,11 +1462,10 @@ func (a *DaprRuntime) initNATS(ctx context.Context) error {
 		}
 
 		natsPublishCallback := func(ctx context.Context, subject string, data []byte) error {
-			_, err := natsJS.Publish(subject, data)
+			_, err = natsJS.Publish(subject, data)
 			return err
 		}
 
-		grpc.RegisterNATSCallback(natsPublishCallback)
 		a.natsPublishCallback = natsPublishCallback
 
 		// Add the NATS connection close method to the runner closer


### PR DESCRIPTION
1. optionally create NATS connection & JetStream creation during runtime initialization: they are only created if the `ENABLE_NATS` environment variable is set to "true"
2. close the NATS connection when runtime shutdown
3. event publishing on successful streaming subscription request via gRPC AP